### PR TITLE
Fixes for build under clang, improved CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
 #
 # Cmake project settings
 #
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 project(dnssd)
 include(CMakeToolsHelpers OPTIONAL)
+include(CMakePackageConfigHelpers)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(_PROJECT_ROOT ${CMAKE_CURRENT_LIST_DIR} CACHE INTERNAL "Root" FORCE)
@@ -18,25 +19,18 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
-if (CMAKE_VERSION VERSION_LESS "3.1")
-    if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-        set (CMAKE_C_FLAGS "--std=c99 ${CMAKE_C_FLAGS}")
-        set (CMAKE_CXX_FLAGS "--std=c++11 ${CMAKE_CXX_FLAGS}")
-    endif()
-else()
-    set (CMAKE_C_STANDARD 99)
-    set (CMAKE_CXX_STANDARD 11)
-endif()
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 11)
 
-    set(source_c_files
-        src/DebugServices.c
-        src/dnssd_clientlib.c
-        src/dnssd_clientstub.c
-        src/dnssd_ipc.c
-        src/GenLinkedList.c
-     )
+set(source_c_files
+    src/DebugServices.c
+    src/dnssd_clientlib.c
+    src/dnssd_clientstub.c
+    src/dnssd_ipc.c
+    src/GenLinkedList.c
+ )
 if(WIN32)
-    set(shared_c_files 
+    set(shared_c_files
         src/dllmain.c
         src/dnssd.def
     )
@@ -53,33 +47,107 @@ if(WIN32)
 else()
     # todo
 endif()
-    add_library(dnssd SHARED ${source_c_files} ${shared_c_files})
-    set_property(TARGET dnssd PROPERTY POSITION_INDEPENDENT_CODE ON)
-    target_include_directories(dnssd PUBLIC src)
+
+# Shared library
+add_library(dnssd SHARED ${source_c_files} ${shared_c_files})
+set_property(TARGET dnssd PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_include_directories(dnssd
+    PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    PUBLIC
+        $<INSTALL_INTERFACE:include>
+)
+
 if(WIN32)
     target_link_libraries(dnssd
-        PRIVATE ws2_32 
+        PRIVATE ws2_32
         PRIVATE iphlpapi
-        PRIVATE secur32 
+        PRIVATE secur32
         PRIVATE crypt32
     )
     set_target_properties(dnssd PROPERTIES PREFIX "")
 else()
     # todo
 endif()
-    add_library(dnssd-static STATIC ${source_c_files})
-    set_property(TARGET dnssd-static PROPERTY POSITION_INDEPENDENT_CODE ON)
-    target_include_directories(dnssd-static PUBLIC src)
 
-    add_executable(dns-sd test/dns-sd.c test/ClientCommon.c)
-    set_property(TARGET dns-sd PROPERTY POSITION_INDEPENDENT_CODE ON)
-    target_include_directories(dns-sd PUBLIC src PUBLIC test)
-    target_compile_definitions(dns-sd 
-        PRIVATE _CONSOLE 
-        PRIVATE NOT_HAVE_GETOPT 
-        PRIVATE NOT_HAVE_SETLINEBUF
+# Static library
+add_library(dnssd-static STATIC ${source_c_files})
+set_property(TARGET dnssd-static PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_include_directories(dnssd-static
+    PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    PUBLIC
+        $<INSTALL_INTERFACE:include>
+)
+
+if(WIN32)
+    target_sources(dnssd-static 
+        PRIVATE
+            src/dllmain.c
     )
-    target_link_libraries(dns-sd PRIVATE dnssd)
-    target_link_libraries(dns-sd
-        PRIVATE ws2_32 
+    target_compile_definitions(dnssd-static
+        PRIVATE
+            mdns_STATIC
     )
+    target_link_libraries(dnssd-static
+        PUBLIC ws2_32
+        PUBLIC iphlpapi
+        PUBLIC secur32
+        PUBLIC crypt32
+    )
+    set_target_properties(dnssd-static PROPERTIES PREFIX "")
+else()
+    # todo
+endif()
+
+add_executable(dns-sd test/dns-sd.c test/ClientCommon.c)
+set_property(TARGET dns-sd PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_include_directories(dns-sd PUBLIC src PUBLIC test)
+target_compile_definitions(dns-sd
+    PRIVATE _CONSOLE
+    PRIVATE NOT_HAVE_GETOPT
+    PRIVATE NOT_HAVE_SETLINEBUF
+)
+target_link_libraries(dns-sd PRIVATE dnssd)
+target_link_libraries(dns-sd
+    PRIVATE ws2_32
+)
+
+# Create and install a config file for making the library useable from CMake
+configure_package_config_file(
+    cmake/DNSSDConfig.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/DNSSDConfig.cmake"
+    INSTALL_DESTINATION lib/cmake
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/DNSSDConfigVersion.cmake"
+    VERSION 1.0.0 
+    COMPATIBILITY SameMajorVersion
+)
+
+install(
+    TARGETS dnssd dnssd-static
+    EXPORT DNSSDTargets
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+install(
+    FILES
+        src/dns_sd.h
+    DESTINATION include
+)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/DNSSDConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/DNSSDConfigVersion.cmake"
+    DESTINATION lib/cmake
+)
+
+install(EXPORT DNSSDTargets
+        DESTINATION lib/cmake
+        NAMESPACE DNSSD::
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ if(WIN32)
         PRIVATE secur32 
         PRIVATE crypt32
     )
+    set_target_properties(dnssd PROPERTIES PREFIX "")
 else()
     # todo
 endif()

--- a/cmake/DNSSDConfig.cmake.in
+++ b/cmake/DNSSDConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+check_required_components(DNSSDTargets)
+include("${CMAKE_CURRENT_LIST_DIR}/DNSSDTargets.cmake")

--- a/src/CommonServices.h
+++ b/src/CommonServices.h
@@ -232,7 +232,6 @@ extern "C" {
     #include    "vxWorks.h"
 
 #elif ( TARGET_OS_WIN32 )
-
 // Windows
 
     #if ( !defined( WIN32_WINDOWS ) )
@@ -260,11 +259,14 @@ extern "C" {
         #pragma warning( disable:4127 ) // Disable "conditional expression is constant" warning for debug macros.
         #pragma warning( disable:4706 ) // Disable "assignment within conditional expression" for Microsoft headers.
 
+    #elif ( defined( __clang__ ) )
+        #include    <stdint.h>
     #endif
 
     #include    <windows.h>
     #include    <winsock2.h>
     #include    <Ws2tcpip.h>
+
 
     #if ( defined( _MSC_VER ) )
         #pragma warning( default:4706 )
@@ -474,7 +476,7 @@ typedef int socklen_t;
 // - Windows
 
 #if ( TARGET_LANGUAGE_C_LIKE )
-    #if ( !defined(_SSIZE_T) && ( TARGET_OS_WIN32 || !defined( _BSD_SSIZE_T_DEFINED_ ) ) && !TARGET_OS_FREEBSD && !TARGET_OS_LINUX && !TARGET_OS_VXWORKS && !TARGET_OS_MAC)
+    #if ( !defined(_SSIZE_T) && ( TARGET_OS_WIN32 || !defined( _BSD_SSIZE_T_DEFINED_ ) ) && !TARGET_OS_FREEBSD && !TARGET_OS_LINUX && !TARGET_OS_VXWORKS && !TARGET_OS_MAC && !defined(__clang__))
 typedef int ssize_t;
     #endif
 #endif
@@ -879,7 +881,11 @@ typedef unsigned long int uintptr_t;
         #define false   0
     #endif
 #else
+#if !defined(__clang__)
     #define COMMON_SERVICES_NEEDS_BOOL          ( !defined( __cplusplus ) && !__bool_true_false_are_defined )
+#else
+    #define COMMON_SERVICES_NEEDS_BOOL          false
+#endif
 #endif
 
 #if ( COMMON_SERVICES_NEEDS_BOOL )

--- a/test-cmake/CMakeLists.txt
+++ b/test-cmake/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.12)
+project(test-dnssd-cmake)
+
+find_package(DNSSD REQUIRED)
+
+add_executable(test-dnssd-cmake main.cpp)
+target_link_libraries(test-dnssd-cmake PRIVATE DNSSD::dnssd)
+
+add_executable(test-dnssd-cmake-static main.cpp)
+target_link_libraries(test-dnssd-cmake-static PRIVATE DNSSD::dnssd-static)

--- a/test-cmake/main.cpp
+++ b/test-cmake/main.cpp
@@ -1,0 +1,6 @@
+#include <dns_sd.h>
+int main()
+{
+    DNSServiceRef client_pa{};
+    DNSServiceCreateConnection(&client_pa);
+}

--- a/test/dns-sd.c
+++ b/test/dns-sd.c
@@ -70,10 +70,15 @@
     #include <ws2tcpip.h>
     #include <Iphlpapi.h>
     #include <process.h>
+#if !defined(__clang__)
 typedef int pid_t;
+
     #define getpid     _getpid
     #define strcasecmp _stricmp
     #define snprintf   _snprintf
+
+#endif
+
 static const char kFilePathSep = '\\';
     #ifndef HeapEnableTerminationOnCorruption
     #     define HeapEnableTerminationOnCorruption (HEAP_INFORMATION_CLASS)1
@@ -83,7 +88,7 @@ static const char kFilePathSep = '\\';
     #endif
     #define if_nametoindex if_nametoindex_win
     #define if_indextoname if_indextoname_win
-
+    
 typedef PCHAR (WINAPI * if_indextoname_funcptr_t)(ULONG index, PCHAR name);
 typedef ULONG (WINAPI * if_nametoindex_funcptr_t)(PCSTR name);
 


### PR DESCRIPTION
I'm using clang on windows and this needed a couple of small fixes. Hopefully this does not break anything else (I also tested that this did not break with VS2019).

Second commit adds the infrastructure to use DNSSD as any other CMake-compatible library - see example in test-cmake.